### PR TITLE
Update for Muzei API 3.4, targetSdkVersion 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,26 +5,25 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.0"
+        classpath "com.android.tools.build:gradle:4.0.1"
     }
 }
 
 apply plugin: "com.android.application"
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
 
     defaultConfig {
         def versionMajor = 2
         def versionMinor = 0
-        def versionPatch = 1
+        def versionPatch = 0
 
         versionName buildVersionName(versionMajor, versionMinor, versionPatch)
         versionCode buildVersionCode(versionMajor, versionMinor, versionPatch)
 
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
     }
 
     signingConfigs {
@@ -64,6 +63,6 @@ dependencies {
         google()
     }
 
-    implementation "com.google.android.apps.muzei:muzei-api:3.2.0"
+    implementation "com.google.android.apps.muzei:muzei-api:3.4.0"
     implementation "com.google.code.gson:gson:2.8.5"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -30,6 +30,22 @@
         android:fullBackupContent="false"
 		tools:ignore="GoogleAppIndexingWarning">
 
+		<activity-alias
+			android:name=".LauncherActivity"
+			android:enabled="@bool/enable_launcher"
+			android:targetActivity=".RedirectActivity">
+
+			<intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
+
+		</activity-alias>
+
+		<activity
+			android:name=".RedirectActivity"
+			android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
 		<provider
 			android:name=".WallpapersProvider"
 			android:authorities="ru.ming13.muzei.earthview"
@@ -40,6 +56,19 @@
 
 			<intent-filter>
 				<action android:name="com.google.android.apps.muzei.api.MuzeiArtProvider"/>
+			</intent-filter>
+
+		</provider>
+
+		<provider
+			android:name="com.google.android.apps.muzei.api.provider.MuzeiArtDocumentsProvider"
+			android:authorities="ru.ming13.muzei.earthview.documents"
+			android:exported="true"
+			android:grantUriPermissions="true"
+			android:permission="android.permission.MANAGE_DOCUMENTS">
+
+			<intent-filter>
+				<action android:name="android.content.action.DOCUMENTS_PROVIDER" />
 			</intent-filter>
 
 		</provider>

--- a/src/main/java/ru/ming13/muzei/earthview/RedirectActivity.java
+++ b/src/main/java/ru/ming13/muzei/earthview/RedirectActivity.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 Artur Dryomov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.ming13.muzei.earthview;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import com.google.android.apps.muzei.api.MuzeiContract;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
+/**
+ * This activity's sole purpose is to redirect users to Muzei, which is where they should
+ * activate Muzei and then select the Earth View source.
+ *
+ * You'll note the usage of the `enable_launcher` boolean resource value to only enable
+ * this on API 29+ devices as it is on API 29+ that a launcher icon becomes mandatory for
+ * every app.
+ */
+public class RedirectActivity extends Activity
+{
+    private static final String EARTH_VIEW_AUTHORITY = "ru.ming13.muzei.earthview";
+    private static final String MUZEI_PACKAGE_NAME = "net.nurik.roman.muzei";
+    private static final String PLAY_STORE_LINK =
+            "https://play.google.com/store/apps/details?id=" + MUZEI_PACKAGE_NAME;
+
+    @Override
+    protected void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // First check whether Earth View is already selected
+        Intent launchIntent = getPackageManager().getLaunchIntentForPackage(MUZEI_PACKAGE_NAME);
+        if (MuzeiContract.Sources.isProviderSelected(this, EARTH_VIEW_AUTHORITY)
+                && launchIntent != null) {
+            // Already selected so just open Muzei
+            startActivityForResult(launchIntent, 1);
+            return;
+        }
+        // Earth View isn't selected, so try to deep link into Muzei's Sources screen
+        Intent deepLinkIntent = MuzeiContract.Sources.createChooseProviderIntent(EARTH_VIEW_AUTHORITY);
+        if (tryStartIntent(deepLinkIntent, R.string.toast_enable)) {
+            return;
+        }
+        // createChooseProviderIntent didn't work, so try to just launch Muzei
+        if (launchIntent != null && tryStartIntent(launchIntent, R.string.toast_enable_source)) {
+            return;
+        }
+        // Muzei isn't installed, so try to open the Play Store so that
+        // users can install Muzei
+        Intent playStoreIntent = new Intent(Intent.ACTION_VIEW).setData(Uri.parse(PLAY_STORE_LINK));
+        if (tryStartIntent(playStoreIntent, R.string.toast_muzei_missing_error)) {
+            return;
+        }
+        // Only if all Intents failed do we show a 'everything failed' Toast
+        Toast.makeText(this, R.string.toast_play_store_missing_error, Toast.LENGTH_LONG).show();
+        finish();
+    }
+
+    private boolean tryStartIntent(@NonNull Intent intent, @StringRes int toastResId) {
+        try {
+            // Use startActivityForResult() so that we get a callback to
+            // onActivityResult() if the user hits the system back button
+            startActivityForResult(intent, 1);
+            Toast.makeText(this, toastResId, Toast.LENGTH_LONG).show();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // It doesn't matter what the result is, the important part is that the
+        // user hit the back button to return to this activity. Since this activity
+        // has no UI of its own, we can simply finish the activity.
+        super.onActivityResult(requestCode, resultCode, data);
+        finish();
+    }
+}

--- a/src/main/java/ru/ming13/muzei/earthview/WallpapersProvider.java
+++ b/src/main/java/ru/ming13/muzei/earthview/WallpapersProvider.java
@@ -27,7 +27,7 @@ import java.util.List;
 public final class WallpapersProvider extends MuzeiArtProvider
 {
 	@Override
-	protected void onLoadRequested(boolean initial) {
+	public void onLoadRequested(boolean initial) {
 		List<Wallpaper> wallpapers = new WallpapersReader(getContext()).readWallpapers();
 		List<Artwork> artworks = new ArrayList<>(wallpapers.size());
 

--- a/src/main/res/values-v29/bools.xml
+++ b/src/main/res/values-v29/bools.xml
@@ -17,14 +17,6 @@
 
 <resources>
 
-	<string name="application_name">Muzei Earth View</string>
-
-	<string name="source_title">Earth View</string>
-	<string name="source_description">Beautiful and unique satellite images from Google Earth</string>
-
-	<string name="toast_enable">Select Earth View in Muzei</string>
-	<string name="toast_enable_source">Select Earth View from the list of Sources in Muzei</string>
-	<string name="toast_muzei_missing_error">You must install Muzei to use this Source</string>
-	<string name="toast_play_store_missing_error">Could not install Muzei from the Google Play Store</string>
+    <bool name="enable_launcher">true</bool>
 
 </resources>

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -17,14 +17,6 @@
 
 <resources>
 
-	<string name="application_name">Muzei Earth View</string>
-
-	<string name="source_title">Earth View</string>
-	<string name="source_description">Beautiful and unique satellite images from Google Earth</string>
-
-	<string name="toast_enable">Select Earth View in Muzei</string>
-	<string name="toast_enable_source">Select Earth View from the list of Sources in Muzei</string>
-	<string name="toast_muzei_missing_error">You must install Muzei to use this Source</string>
-	<string name="toast_play_store_missing_error">Could not install Muzei from the Google Play Store</string>
+    <bool name="enable_launcher">false</bool>
 
 </resources>


### PR DESCRIPTION
Muzei API 3.4 adds a lot of things that are specifically useful for Earth View:

- Muzei API 3.4 drastically increases the speed when setting a large number of images at once (which is exactly what `WallpaperProviders` does), meaning it loads in ~2-3 seconds rather than 30+ seconds.
- A launch activity is required on Android 10 (API 29) or higher devices. Muzei 3.4 adds new `MuzeiContract` APIs for redirecting users to the right screen in Muzei as seen in the `RedirectActivity`.

To get Earth View working with Muzei API 3.4, this also upgrades to Android Gradle Plugin 4.0.1, Gradle 6.5, a `compileSdkVersion` and `targetSdkVersion` of 30, and switches to AndroidX.